### PR TITLE
Match routes by order (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-node_modules
-dist
+/.vscode/
+/node_modules/
+/dist/
+/index.html

--- a/README.md
+++ b/README.md
@@ -48,13 +48,24 @@ const App = () => (
 
 ## API
 
-| Prop        | Type      | Required | Default   | Description                                                                                              |
-| ----------- | --------- | -------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| `animation` | `string`  |          | `'slide'` | Animation effect type, `'slide'`, `'vertical-slide'`, or `'rotate'`                                      |
-| `pathList`  | `array`   |          | `[]`      | Pre-defined `pathname` list, useful when enter a url, you want to "back" to some url (default "forward") |
-| `duration`  | `number`  |          | `200`     | `transition-duration` in `ms`                                                                            |
-| `timing`    | `string`  |          | `'ease'`  | `transition-timing-function`, one of `'ease'` `'ease-in'` `'ease-out'` `'ease-in-out'` `'linear'`        |
-| `destroy`   | `boolean` |          | `true`    | If `false`, prev page will still exits in dom, just invisible                                            |
+| Prop        | Type       | Required | Default   | Description                                                                                              |
+| ----------- | ---------- | -------- | --------- | -------------------------------------------------------------------------------------------------------- |
+| `animation` | `string`   |          | `'slide'` | Animation effect type, `'slide'`, `'vertical-slide'`, or `'rotate'`                                      |
+| `compare`   | `function` |          | `null`    | Comparison function that defines route order, defaults to definition order; see below for details        |
+| `duration`  | `number`   |          | `200`     | `transition-duration` in `ms`                                                                            |
+| `timing`    | `string`   |          | `'ease'`  | `transition-timing-function`, one of `'ease'` `'ease-in'` `'ease-out'` `'ease-in-out'` `'linear'`        |
+| `destroy`   | `boolean`  |          | `true`    | If `false`, prev page will still exits in dom, just invisible                                            |
+
+The `compare` prop works similarly to [`Array.prototype.sort`][sort]’s `compareFn` argument.
+It takes two arguments “a” and “b”, both react-router’s [`RouteObject`s][route].
+The return value is `-1` if “a” sorts before “b”, `1` if after, and `0` if they should stay in original order:
+
+```ts
+(a: RouteObject, b: RouteObject) => -1 | 0 | 1 
+```
+
+[sort]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#syntax
+[route]: https://reactrouter.com/en/main/hooks/use-routes
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "watch": "rollup -wc --configPlugin @rollup/plugin-typescript",
     "build": "rm -rf dist && rollup -c --configPlugin @rollup/plugin-typescript",
-    "prepack": "pnpm build"
+    "prepack": "$npm_execpath run build"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   ],
   "scripts": {
     "watch": "rollup -wc --configPlugin @rollup/plugin-typescript",
-    "build": "rm -rf dist && rollup -c --configPlugin @rollup/plugin-typescript"
+    "build": "rm -rf dist && rollup -c --configPlugin @rollup/plugin-typescript",
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "react": ">=16.8.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,17 +1,20 @@
 import { readFileSync } from 'fs';
 import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
+import { RollupOptions } from 'rollup';
 
 const pkg = JSON.parse(readFileSync('./package.json') as unknown as string);
 
 const input = 'src/index.tsx';
-const cjsOutput = { file: pkg.main, format: 'cjs', exports: 'auto' };
-const esmOutput = { file: pkg.module, format: 'es' };
-const dtsOutput = { file: pkg.types, format: 'es' };
+const cjsOutput = { file: pkg.main, format: 'cjs', exports: 'auto' } as const;
+const esmOutput = { file: pkg.module, format: 'es' } as const;
+const dtsOutput = { file: pkg.types, format: 'es' } as const;
 const external = () => true;
 
-export default [
+const config: RollupOptions[] = [
   { input, output: cjsOutput, plugins: [typescript()], external },
   { input, output: esmOutput, plugins: [typescript()], external },
   { input, output: dtsOutput, plugins: [dts()] },
 ];
+
+export default config;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -156,6 +156,7 @@ const isRouteElement = (e: ReactNode): e is RouteElement => isValidElement(e) &&
 
 export type SlideRoutesProps = {
   animation?: 'slide' | 'vertical-slide' | 'rotate';
+  compare?(a: RouteObject, b: RouteObject): -1|0|1;
   duration?: number;
   timing?: 'ease' | 'ease-in' | 'ease-out' | 'ease-in-out' | 'linear';
   destroy?: boolean;
@@ -165,6 +166,7 @@ export type SlideRoutesProps = {
 const SlideRoutes = (props: SlideRoutesProps) => {
   const {
     animation = 'slide',
+    compare = null,
     duration = 200,
     timing = 'ease',
     destroy = true,
@@ -197,9 +199,12 @@ const SlideRoutes = (props: SlideRoutesProps) => {
     return { ...child, props: { ...restProps, element: newElement } };
   })!;
   const routeObjects = createRoutesFromElements(routeElements);
-  const routes: RouteRef[] = routeObjects.map((route, i) => ({ route, nodeRef: nodeRefs[i] }));
-
   const routesElement = useRoutes(routeObjects, location);
+
+  const routes = routeObjects.map<RouteRef>((route, i) => ({ route, nodeRef: nodeRefs[i] }));
+  if (compare) {
+    routes.sort((a, b) => compare(a.route, b.route));
+  }
 
   const next = findRoute(routes, relPath);
   if (prevRelPath.current && prevRelPath.current !== relPath) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
-import { useMemo, useRef, cloneElement, Children, isValidElement, useContext, createRef, RefObject } from 'react';
+import { useMemo, useRef, cloneElement, useContext, RefObject, Children, createRef, isValidElement, ReactNode } from 'react';
 import type { ReactElement } from 'react';
-import { useLocation, useRoutes, createRoutesFromElements, matchRoutes, UNSAFE_RouteContext } from 'react-router-dom';
+import { useLocation, useRoutes, createRoutesFromElements, matchRoutes, UNSAFE_RouteContext, Route, Navigate } from 'react-router-dom';
 import type { RouteObject, RouteProps, NavigateProps } from 'react-router-dom';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
@@ -149,7 +149,10 @@ const findRoute = (routes: RouteRef[], pathname: string) => {
   return { index, nodeRef: routes[index].nodeRef };
 }
 
-type ChildElement = ReactElement<RouteProps> | ReactElement<NavigateProps>;
+type RouteElement = ReactElement<RouteProps, typeof Route>;
+type NavigateElement = ReactElement<NavigateProps, typeof Navigate>;
+type ChildElement = RouteElement | NavigateElement;
+const isRouteElement = (e: ReactNode): e is RouteElement => isValidElement(e) && e.type === Route
 
 export type SlideRoutesProps = {
   animation?: 'slide' | 'vertical-slide' | 'rotate';
@@ -181,13 +184,10 @@ const SlideRoutes = (props: SlideRoutesProps) => {
 
   const nodeRefs: RefObject<HTMLDivElement>[] = [];
   const routeElements = Children.map(children, (child) => {
-    if (!child || !isValidElement(child)) {
+    if (!isRouteElement(child)) {
       return child;
     }
-    if ('replace' in child.props && child.props.replace === true) {
-      return child;
-    }
-    const { element, ...restProps } = child.props as RouteProps;
+    const { element, ...restProps } = child.props;
     if (!element) {
       return child;
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,10 +5,16 @@ import { useLocation, useRoutes, createRoutesFromChildren, matchRoutes, UNSAFE_R
 import type { RouteObject, RouteProps, NavigateProps } from 'react-router-dom';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
 
-type Direction = 'forward' | 'back' | null;
+type Direction = 'forward' | 'back' | 'undirected';
 
-const sign2direction = new Map<number, Direction>([[-1, 'back'], [0, null], [1, 'forward']]);
-
+const getDirection = (prevIndex: number, nextIndex: number): Direction => {
+  switch (Math.sign(nextIndex - prevIndex) as (-1|0|1)) {
+    case -1: return 'back';
+    case 0: return 'undirected';
+    case 1: return 'forward';
+  }
+}
+  
 const getCss = (duration: number, timing: string, direction: Direction) => css`
   display: grid;
 
@@ -163,7 +169,7 @@ const SlideRoutes = (props: SlideRoutesProps) => {
   const relPath = useRelPath(location.pathname);
 
   const prevRelPath = useRef<string | null>(null);
-  const direction = useRef<Direction>(null);
+  const direction = useRef<Direction>('undirected');
 
   const cssProps = useMemo(
     () => (destroy ? { timeout: duration } : { addEndListener() {} }),
@@ -193,7 +199,7 @@ const SlideRoutes = (props: SlideRoutesProps) => {
   if (prevRelPath.current && prevRelPath.current !== relPath) {
     const prevIndex = findRouteIndex(routes, prevRelPath.current);
     const nextIndex = findRouteIndex(routes, relPath);
-    direction.current = sign2direction.get(Math.sign(nextIndex - prevIndex))!;
+    direction.current = getDirection(prevIndex, nextIndex);
   }
   prevRelPath.current = relPath;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
-import { useMemo, useRef, cloneElement, useContext, RefObject, Children, createRef, isValidElement, ReactNode } from 'react';
-import type { ReactElement } from 'react';
+import { useMemo, useRef, useContext, cloneElement, createRef, isValidElement, Children, useCallback} from 'react';
+import type { RefObject, ReactElement, ReactNode } from 'react';
 import { useLocation, useRoutes, createRoutesFromElements, matchRoutes, UNSAFE_RouteContext, Route, Navigate } from 'react-router-dom';
 import type { RouteObject, RouteProps, NavigateProps } from 'react-router-dom';
 import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import type { CSSTransitionProps } from 'react-transition-group/CSSTransition';
 
 type Direction = 'forward' | 'back' | 'undirected';
 
@@ -94,7 +95,7 @@ const findRoute = (routes: RouteRef[], pathname: string) => {
   const matches = matchRoutes(routes.map(({route}) => route), pathname);
   if (matches === null) throw new Error(`Route ${pathname} does not match`);
   const index = routes.findIndex(({route}) => matches.some((match) => route === match.route));
-  return { index, nodeRef: routes[index].nodeRef };
+  return { index, ...routes[index] };
 }
 
 type RouteElement = ReactElement<RouteProps, typeof Route>;
@@ -161,15 +162,18 @@ const SlideRoutes = (props: SlideRoutesProps) => {
   }
   prevRelPath.current = relPath;
 
+  const childFactory = useCallback(
+    (child: ReactElement<CSSTransitionProps>) => cloneElement(child, { classNames: direction.current }),
+    [],
+  );
+
   return (
     <TransitionGroup
       className={`slide-routes ${animation}`}
-      childFactory={(child) =>
-        cloneElement(child, { classNames: direction.current })
-      }
+      childFactory={childFactory}
       css={getCss(duration, timing, direction.current)}
     >
-      <CSSTransition key={relPath} nodeRef={next.nodeRef} {...cssProps}>
+      <CSSTransition key={next.route.path ?? next.index} nodeRef={next.nodeRef} {...cssProps}>
         {routesElement}
       </CSSTransition>
     </TransitionGroup>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -18,7 +18,7 @@ const getDirection = (prevIndex: number, nextIndex: number): Direction => {
 const getCss = (duration: number, timing: string, direction: Direction) => css`
   display: grid;
 
-  .item {
+  & > .item {
     grid-area: 1 / 1 / 2 / 2;
 
     &:not(:only-child) {
@@ -32,30 +32,30 @@ const getCss = (duration: number, timing: string, direction: Direction) => css`
     overflow: hidden;
 
     // back
-    .back-enter {
+    & > .back-enter {
       transform: translateX(-100%);
     }
-    .back-enter-active {
+    & > .back-enter-active {
       transform: translateX(0);
     }
-    .back-exit {
+    & > .back-exit {
       transform: translateX(0);
     }
-    .back-exit-active {
+    & > .back-exit-active {
       transform: translateX(100%);
     }
 
     // forward
-    .forward-enter {
+    & > .forward-enter {
       transform: translateX(100%);
     }
-    .forward-enter-active {
+    & > .forward-enter-active {
       transform: translateX(0);
     }
-    .forward-exit {
+    & > .forward-exit {
       transform: translateX(0);
     }
-    .forward-exit-active {
+    & > .forward-exit-active {
       transform: translateX(-100%);
     }
   }
@@ -64,30 +64,30 @@ const getCss = (duration: number, timing: string, direction: Direction) => css`
     overflow: hidden;
 
     // back
-    .back-enter {
+    & > .back-enter {
       transform: translateY(-100%);
     }
-    .back-enter-active {
+    & > .back-enter-active {
       transform: translateY(0);
     }
-    .back-exit {
+    & > .back-exit {
       transform: translateY(0);
     }
-    .back-exit-active {
+    & > .back-exit-active {
       transform: translateY(100%);
     }
 
     // forward
-    .forward-enter {
+    & > .forward-enter {
       transform: translateY(100%);
     }
-    .forward-enter-active {
+    & > .forward-enter-active {
       transform: translateY(0);
     }
-    .forward-exit {
+    & > .forward-exit {
       transform: translateY(0);
     }
-    .forward-exit-active {
+    & > .forward-exit-active {
       transform: translateY(-100%);
     }
   }
@@ -95,35 +95,35 @@ const getCss = (duration: number, timing: string, direction: Direction) => css`
   &.rotate {
     perspective: 2000px;
 
-    .item {
+    & > .item {
       backface-visibility: hidden;
     }
 
     // back
-    .back-enter {
+    & > .back-enter {
       transform: rotateY(-180deg);
     }
-    .back-enter-active {
+    & > .back-enter-active {
       transform: rotateY(0);
     }
-    .back-exit {
+    & > .back-exit {
       transform: rotateY(0);
     }
-    .back-exit-active {
+    & > .back-exit-active {
       transform: rotateY(180deg);
     }
 
     // forward
-    .forward-enter {
+    & > .forward-enter {
       transform: rotateY(180deg);
     }
-    .forward-enter-active {
+    & > .forward-enter-active {
       transform: rotateY(0);
     }
-    .forward-exit {
+    & > .forward-exit {
       transform: rotateY(0);
     }
-    .forward-exit-active {
+    & > .forward-exit-active {
       transform: rotateY(-180deg);
     }
   }
@@ -179,29 +179,27 @@ const SlideRoutes = (props: SlideRoutesProps) => {
     [destroy, duration]
   );
 
-  const routes: RouteRef[] = useMemo(() => {
-    const nodeRefs: RefObject<HTMLDivElement>[] = [];
-    const routeElements = Children.map(children, (child) => {
-      if (!child || !isValidElement(child)) {
-        return child;
-      }
-      if ('replace' in child.props && child.props.replace === true) {
-        return child;
-      }
-      const { element, ...restProps } = child.props as RouteProps;
-      if (!element) {
-        return child;
-      }
-      const nodeRef = createRef<HTMLDivElement>();
-      nodeRefs.push(nodeRef);
-      const newElement = <div className="item" ref={nodeRef}>{element}</div>;
-      return { ...child, props: { ...restProps, element: newElement } };
-    })!;
-    const routeObjects = createRoutesFromElements(routeElements);
-    return routeObjects.map((route, i) => ({ route, nodeRef: nodeRefs[i] }));
-  }, [children]);
+  const nodeRefs: RefObject<HTMLDivElement>[] = [];
+  const routeElements = Children.map(children, (child) => {
+    if (!child || !isValidElement(child)) {
+      return child;
+    }
+    if ('replace' in child.props && child.props.replace === true) {
+      return child;
+    }
+    const { element, ...restProps } = child.props as RouteProps;
+    if (!element) {
+      return child;
+    }
+    const nodeRef = createRef<HTMLDivElement>();
+    nodeRefs.push(nodeRef);
+    const newElement = <div className="item" ref={nodeRef}>{element}</div>;
+    return { ...child, props: { ...restProps, element: newElement } };
+  })!;
+  const routeObjects = createRoutesFromElements(routeElements);
+  const routes: RouteRef[] = routeObjects.map((route, i) => ({ route, nodeRef: nodeRefs[i] }));
 
-  const routesElement = useRoutes(routes.map(({route}) => route), location);
+  const routesElement = useRoutes(routeObjects, location);
 
   const next = findRoute(routes, relPath);
   if (prevRelPath.current && prevRelPath.current !== relPath) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,6 +14,36 @@ const getDirection = (prevIndex: number, nextIndex: number): Direction => {
     case 1: return 'forward';
   }
 }
+
+const cssTransitions = (cssFunc: string, max: string) => `
+  // back
+  & > .back-enter {
+    transform: ${cssFunc}(-${max});
+  }
+  & > .back-enter-active {
+    transform: ${cssFunc}(0);
+  }
+  & > .back-exit {
+    transform: ${cssFunc}(0);
+  }
+  & > .back-exit-active {
+    transform: ${cssFunc}(${max});
+  }
+
+  // forward
+  & > .forward-enter {
+    transform: ${cssFunc}(${max});
+  }
+  & > .forward-enter-active {
+    transform: ${cssFunc}(0);
+  }
+  & > .forward-exit {
+    transform: ${cssFunc}(0);
+  }
+  & > .forward-exit-active {
+    transform: ${cssFunc}(-${max});
+  }
+`;
   
 const getCss = (duration: number, timing: string, direction: Direction) => css`
   display: grid;
@@ -30,102 +60,20 @@ const getCss = (duration: number, timing: string, direction: Direction) => css`
 
   &.slide {
     overflow: hidden;
-
-    // back
-    & > .back-enter {
-      transform: translateX(-100%);
-    }
-    & > .back-enter-active {
-      transform: translateX(0);
-    }
-    & > .back-exit {
-      transform: translateX(0);
-    }
-    & > .back-exit-active {
-      transform: translateX(100%);
-    }
-
-    // forward
-    & > .forward-enter {
-      transform: translateX(100%);
-    }
-    & > .forward-enter-active {
-      transform: translateX(0);
-    }
-    & > .forward-exit {
-      transform: translateX(0);
-    }
-    & > .forward-exit-active {
-      transform: translateX(-100%);
-    }
+    ${cssTransitions('translateX', '100%')}
   }
 
   &.vertical-slide {
     overflow: hidden;
-
-    // back
-    & > .back-enter {
-      transform: translateY(-100%);
-    }
-    & > .back-enter-active {
-      transform: translateY(0);
-    }
-    & > .back-exit {
-      transform: translateY(0);
-    }
-    & > .back-exit-active {
-      transform: translateY(100%);
-    }
-
-    // forward
-    & > .forward-enter {
-      transform: translateY(100%);
-    }
-    & > .forward-enter-active {
-      transform: translateY(0);
-    }
-    & > .forward-exit {
-      transform: translateY(0);
-    }
-    & > .forward-exit-active {
-      transform: translateY(-100%);
-    }
+    ${cssTransitions('translateY', '100%')}
   }
 
   &.rotate {
     perspective: 2000px;
-
     & > .item {
       backface-visibility: hidden;
     }
-
-    // back
-    & > .back-enter {
-      transform: rotateY(-180deg);
-    }
-    & > .back-enter-active {
-      transform: rotateY(0);
-    }
-    & > .back-exit {
-      transform: rotateY(0);
-    }
-    & > .back-exit-active {
-      transform: rotateY(180deg);
-    }
-
-    // forward
-    & > .forward-enter {
-      transform: rotateY(180deg);
-    }
-    & > .forward-enter-active {
-      transform: rotateY(0);
-    }
-    & > .forward-exit {
-      transform: rotateY(0);
-    }
-    & > .forward-exit-active {
-      transform: rotateY(-180deg);
-    }
+    ${cssTransitions('rotateY', '180deg')}
   }
 `;
 
@@ -152,7 +100,7 @@ const findRoute = (routes: RouteRef[], pathname: string) => {
 type RouteElement = ReactElement<RouteProps, typeof Route>;
 type NavigateElement = ReactElement<NavigateProps, typeof Navigate>;
 type ChildElement = RouteElement | NavigateElement;
-const isRouteElement = (e: ReactNode): e is RouteElement => isValidElement(e) && e.type === Route
+const isRouteElement = (e: ReactNode): e is RouteElement => isValidElement(e) && e.type === Route;
 
 export type SlideRoutesProps = {
   animation?: 'slide' | 'vertical-slide' | 'rotate';


### PR DESCRIPTION
New attempt for #22.

- [x] Default to route definition order and add a way to customize order. Fixes #23
- [x] Handle nested usage. Fixes #14
- [x] Allow using in React 18’s `StrictMode` without warnings. Fixes #2